### PR TITLE
Changed include to include_tasks

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -5,4 +5,4 @@
   when: ansible_distribution == 'Archlinux'
 
 - name: apprise.yaml
-  include: apprise.yaml
+  include_tasks: apprise.yaml


### PR DESCRIPTION
Changed include to include_tasks because of deprecation in version 2.16.